### PR TITLE
Fix password entropy with special characters

### DIFF
--- a/stringen/utils.py
+++ b/stringen/utils.py
@@ -111,6 +111,9 @@ def password_entropy(text: str) -> float:
             charset += 26
         if any(c.isdigit() for c in text):
             charset += 10
+        # Account for special characters by counting the unique symbols
+        specials = {c for c in text if not c.isalnum()}
+        charset += len(specials)
     if charset == 0:
         return 0.0
     return len(text) * math.log2(charset)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@
 import string
 import sys
 from pathlib import Path
+import math
 import pytest
 
 from stringen.cli import parse_args, main
@@ -153,6 +154,12 @@ def test_recognized_base():
     assert recognized_base('123') == 8
     assert recognized_base('7ab') == 16
     assert recognized_base('abc') == 16
+
+
+def test_password_entropy_special_chars():
+    """password_entropy counts unique special characters."""
+    result = password_entropy('!@#$')
+    assert result == pytest.approx(len('!@#$') * math.log2(4))
 
 
 def test_main_base_output_entropy(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- count unique special characters when computing password entropy
- test password entropy with special characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fad2a08883299170b12f1697d5ec