### PR TITLE
Add special character enforcement

### DIFF
--- a/stringen/cli.py
+++ b/stringen/cli.py
@@ -10,6 +10,7 @@ from . import __version__
 from .utils import (
     build_charset,
     generate_string,
+    generate_string_mixed,
     recognized_base,
     password_entropy,
     positive_int,
@@ -206,15 +207,19 @@ def main() -> None:
         return
 
     try:
-        charset = build_charset(args)
+        groups = build_charset(args, as_groups=True)
     except argparse.ArgumentTypeError as exc:
         parser.error(str(exc))
+    charset = "".join(groups)
     if not charset:
         parser.error(
             "No character set selected. Use -a, -A, -i/-10, -b, -o or -x"
         )
 
-    result = generate_string(args.length, charset)
+    if len(groups) > 1:
+        result = generate_string_mixed(args.length, groups)
+    else:
+        result = generate_string(args.length, charset)
     if args.file is not None:
         try:
             with open(args.file, "w", encoding="utf-8") as fh:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -204,6 +204,14 @@ def test_main_generation_to_file(monkeypatch, tmp_path, capsys):
     assert 'Length:' in lines[0]
 
 
+def test_main_mixed_special_chars(monkeypatch, capsys):
+    """Generated strings include at least one special character when -s is used."""
+    monkeypatch.setattr(sys, 'argv', ['stringen', '-c', '-a', '-A', '-i', '-s', '!@', '8'])
+    main()
+    generated = capsys.readouterr().out.strip()
+    assert any(ch in '!@' for ch in generated)
+
+
 def test_main_illegal_char_cli(monkeypatch):
     """Non printable characters in -r abort the program."""
     monkeypatch.setattr(sys, 'argv', ['stringen', '-r', 'abc\x01'])


### PR DESCRIPTION
## Summary
- tweak build_charset to optionally return groups
- ensure at least one of each selected char group is used when generating strings
- update CLI to use the new mixed generation function
- test mixed generation with special characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842067b192c83299845eb1c78d68b82