### PR TITLE
Fix short length handling in mixed generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ python -m stringen --help
 - Optional uppercase letters (`-A`)
 - Optional Hexadecimal output (`-x`/`-16`/`--hex`) respecting `-a`/`-A` for case
 - Hexadecimal mode uses random case when `-a` and `-A` are both omitted or both present
+- When mixed case is allowed, the hex digits `a-f`/`A-F` and `0-9` form a 22-symbol
+  pool, so digits occur slightly less often than in standard hex
 - Optional special characters (`-s [STRING|CHARSET_FILE]`, defaults to `charsets/special_charset_default.txt`)
 - Read input from or write output to a file via `-f [FILE]`
 - Aborts when the provided string contains non-printable characters

--- a/stringen/utils.py
+++ b/stringen/utils.py
@@ -76,12 +76,19 @@ def generate_string(length: int, charset: str) -> str:
 
 
 def generate_string_mixed(length: int, groups: list[str]) -> str:
-    """Generate a string ensuring at least one character from each group."""
+    """Generate a string from multiple groups.
+
+    When ``length`` is at least the number of groups, ensure the result contains
+    one character from each group. Otherwise, select random characters from the
+    combined set.
+    """
     if not groups:
         return ""
     all_chars = "".join(groups)
+    if length < len(groups):
+        return generate_string(length, all_chars)
     result = [secrets.choice(group) for group in groups]
-    for _ in range(max(length - len(groups), 0)):
+    for _ in range(length - len(groups)):
         result.append(secrets.choice(all_chars))
     secrets.SystemRandom().shuffle(result)
     return "".join(result)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -227,3 +227,11 @@ def test_main_illegal_char_file(monkeypatch, tmp_path):
     with pytest.raises(SystemExit):
         main()
 
+
+def test_main_length_shorter_than_groups(monkeypatch, capsys):
+    """When length is less than the groups, output still has requested length."""
+    monkeypatch.setattr(sys, 'argv', ['stringen', '-a', '-A', '-i', '2'])
+    main()
+    out = capsys.readouterr().out.strip()
+    assert len(out.splitlines()[0]) == 2
+


### PR DESCRIPTION
## Summary
- allow mixed generation when length is less than the number of groups
- remove CLI error for short lengths
- update regression test accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684208370fa88329919da8badfaa67e8