### PR TITLE
Add doc clarification

### DIFF
--- a/stringen/cli.py
+++ b/stringen/cli.py
@@ -139,6 +139,8 @@ def parse_args(
     processed: list[str] = []
     for arg in arguments:
         if arg == "-rf":
+            # Allow the short option combination "-rf" to behave like
+            # passing "-r" and "-f" separately.
             processed.extend(["-r", "-f"])
         else:
             processed.append(arg)

--- a/stringen/utils.py
+++ b/stringen/utils.py
@@ -107,7 +107,12 @@ def shannon_entropy(text: str) -> float:
 
 
 def recognized_base(text: str) -> int:
-    """Return recognized numeric base of the given text."""
+    """Return recognized numeric base of the given text.
+
+    The smallest base capable of representing all characters is returned.
+    Hexadecimal is only detected when letters ``a``-``f`` or ``A``-``F`` are
+    present.
+    """
     if not text:
         return 0
     hex_chars = set("0123456789abcdefABCDEF")


### PR DESCRIPTION
## Summary
- clarify how `-rf` is handled in argument preprocessing
- detail base detection heuristic in utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684223cb9ad88329b7945de6c689d447