### PR TITLE
Enhance base output

### DIFF
--- a/stringen/cli.py
+++ b/stringen/cli.py
@@ -12,6 +12,7 @@ from .utils import (
     generate_string,
     generate_string_mixed,
     recognized_base,
+    character_set_size,
     password_entropy,
     positive_int,
     shannon_entropy,
@@ -164,6 +165,7 @@ def main() -> None:
         sh_total = sh_entropy * text_length
         pw_entropy = password_entropy(args.entropy)
         base = recognized_base(args.entropy)
+        charset_size = character_set_size(args.entropy)
         if args.clean:
             logger.info(f"{pw_entropy:.2f}")
             return
@@ -172,7 +174,7 @@ def main() -> None:
             f"Shannon entropy: {sh_entropy:.2f} bits/char ({sh_total:.2f} bits total)"
         )
         logger.info(f"Password entropy: {pw_entropy:.2f} bits")
-        logger.info(f"Base: {base}")
+        logger.info(f"Base: {base} (Character Set: {charset_size})")
         return
 
     if args.file is not None and args.entropy is not None:
@@ -199,8 +201,11 @@ def main() -> None:
             logger.info(
                 f"Shannon entropy: {sh_entropy:.2f} bits/char ({sh_total:.2f} bits total)"
             )
+            charset_size = character_set_size(line)
             logger.info(f"Password entropy: {pw_entropy:.2f} bits")
-            logger.info(f"Recognized base: {base}")
+            logger.info(
+                f"Recognized base: {base} (Character Set: {charset_size})"
+            )
         return
 
     try:
@@ -230,12 +235,15 @@ def main() -> None:
         sh_total = sh_entropy * result_length
         pw_entropy = password_entropy(result)
         base = recognized_base(result)
+        charset_size = character_set_size(result)
         logger.info(f"Length: {result_length}")
         logger.info(
             f"Shannon entropy: {sh_entropy:.2f} bits/char ({sh_total:.2f} bits total)"
         )
         logger.info(f"Password entropy: {pw_entropy:.2f} bits")
-        logger.info(f"Recognized base: {base}")
+        logger.info(
+            f"Recognized base: {base} (Character Set: {charset_size})"
+        )
         return
     if args.clean:
         logger.info(result)
@@ -245,11 +253,12 @@ def main() -> None:
     sh_total = sh_entropy * result_length
     pw_entropy = password_entropy(result)
     base = recognized_base(result)
+    charset_size = character_set_size(result)
     logger.info(result)
     logger.info(f"Length: {result_length}")
     logger.info(
         f"Shannon entropy: {sh_entropy:.2f} bits/char ({sh_total:.2f} bits total)"
     )
     logger.info(f"Password entropy: {pw_entropy:.2f} bits")
-    logger.info(f"Recognized base: {base}")
+    logger.info(f"Recognized base: {base} (Character Set: {charset_size})")
 

--- a/stringen/utils.py
+++ b/stringen/utils.py
@@ -128,6 +128,27 @@ def recognized_base(text: str) -> int:
     return 0
 
 
+def character_set_size(text: str) -> int:
+    """Return the size of the character set present in ``text``."""
+    if not text:
+        return 0
+    base = recognized_base(text)
+    if base:
+        return base
+
+    size = 0
+    if any(c.islower() for c in text):
+        size += 26
+    if any(c.isupper() for c in text):
+        size += 26
+    if any(c.isdigit() for c in text):
+        size += 10
+    specials = {c for c in text if not c.isalnum()}
+    size += len(specials)
+
+    return size
+
+
 def password_entropy(text: str) -> float:
     """Return password entropy based on character set size and length."""
     if not text:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -168,7 +168,7 @@ def test_main_base_output_entropy(monkeypatch, capsys):
     main()
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
-    assert lines[-1] == 'Base: 2'
+    assert lines[-1] == 'Base: 2 (Character Set: 2)'
 
 
 def test_main_base_output_generation(monkeypatch, capsys):
@@ -177,7 +177,7 @@ def test_main_base_output_generation(monkeypatch, capsys):
     main()
     captured = capsys.readouterr()
     lines = captured.out.strip().splitlines()
-    assert lines[-1] == 'Recognized base: 2'
+    assert lines[-1] == 'Recognized base: 2 (Character Set: 2)'
 
 
 def test_main_entropy_from_file(monkeypatch, tmp_path, capsys):
@@ -188,8 +188,8 @@ def test_main_entropy_from_file(monkeypatch, tmp_path, capsys):
     main()
     captured = capsys.readouterr()
     lines = [l for l in captured.out.strip().splitlines() if l]
-    assert 'Recognized base: 16' in lines
-    assert 'Recognized base: 2' in lines
+    assert 'Recognized base: 16 (Character Set: 16)' in lines
+    assert 'Recognized base: 2 (Character Set: 2)' in lines
 
 
 def test_main_entropy_from_file_clean(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- show size of the detected character set when printing base
- provide `character_set_size` helper
- test updated CLI output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422d947ac08329965ef4b4f82a977d