### PR TITLE
Fix -s in short option clusters

### DIFF
--- a/stringen/cli.py
+++ b/stringen/cli.py
@@ -143,6 +143,18 @@ def parse_args(
             # Allow the short option combination "-rf" to behave like
             # passing "-r" and "-f" separately.
             processed.extend(["-r", "-f"])
+        elif (
+            arg.startswith("-")
+            and not arg.startswith("--")
+            and len(arg) > 2
+            and arg.endswith("s")
+        ):
+            # Handle clusters like "-aAis" where "-s" is specified without
+            # its optional argument. Split the other flags and add an empty
+            # argument so -s uses the default special character set.
+            for opt in arg[1:-1]:
+                processed.append(f"-{opt}")
+            processed.extend(["-s", ""])
         else:
             processed.append(arg)
     return parser.parse_args(processed), parser

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,6 +111,23 @@ def test_spec_default_file():
     assert charset == default_chars
 
 
+def test_spec_cluster_default_file():
+    """Short option clusters ending with -s use the default file."""
+    args, _ = parse_args(['-aAis', '8'])
+    charset = build_charset(args)
+    default_path = (
+        Path(__file__).resolve().parent.parent
+        / 'stringen'
+        / 'charsets'
+        / 'special_charset_default.txt'
+    )
+    default_chars = default_path.read_text().strip()
+    for ch in default_chars:
+        assert ch in charset
+    assert args.spec == ''
+    assert args.length == 8
+
+
 def test_clean_flag_parsing():
     """The -c flag is parsed correctly."""
     args, _ = parse_args(['-c'])


### PR DESCRIPTION
## Summary
- handle short option clusters that end with `-s`
- ensure default special charset is used when `-s` appears in a cluster without an argument
- add regression test for `-aAis` cluster

## Testing
- `pytest -q`
- `python -m stringen -aAis 8`

------
https://chatgpt.com/codex/tasks/task_e_6842c0d3fd608329819466cbcc4d89b2